### PR TITLE
Implement initial JSKOS API 2.1 client

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ kos = jskos.read(url)
 processed_kos = jskos.process(kos)
 ```
 
-A [JSKOS API](https://github.com/gbv/jskos-server) can be accessed with the following:
+A [JSKOS API](https://github.com/gbv/jskos-server) can be accessed with the
+following:
 
 ```python
 from jskos import JSKOSClient

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ kos = jskos.read(url)
 processed_kos = jskos.process(kos)
 ```
 
+A [JSKOS API](https://github.com/gbv/jskos-server) can be accessed with the following:
+
+```python
+from jskos import JSKOSClient
+
+client = JSKOSClient("https://coli-conc.gbv.de/api/")
+
+# see https://github.com/gbv/jskos-server#get-voc
+vocabularies = client.get_vocabularies(limit=1)
+```
+
 ## 🚀 Installation
 
 The most recent release can be installed from

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ from jskos import JSKOSClient
 client = JSKOSClient("https://coli-conc.gbv.de/api/")
 
 # see https://github.com/gbv/jskos-server#get-voc
-vocabularies = client.get_vocabularies(limit=1)
+vocabularies = client.get_concept_schemes(limit=1)
 ```
 
 ## 🚀 Installation

--- a/src/jskos/__init__.py
+++ b/src/jskos/__init__.py
@@ -13,6 +13,7 @@ from .api import (
     process,
     read,
 )
+from .client import JSKOSClient
 
 __all__ = [
     "KOS",
@@ -20,6 +21,7 @@ __all__ = [
     "ConceptBundle",
     "ConceptScheme",
     "Item",
+    "JSKOSClient",
     "Mapping",
     "ProcessedConcept",
     "ProcessedKOS",

--- a/src/jskos/api.py
+++ b/src/jskos/api.py
@@ -149,9 +149,9 @@ class ResourceMixin(BaseModel):
     uri: AnyUrl | None = None
     identifier: list[AnyUrl] | None = None
     type: list[AnyUrl] | None = None
-    created: datetime.date | None = None
-    issued: datetime.date | None = None
-    modified: datetime.date | None = None
+    created: datetime.datetime | datetime.date | None = None
+    issued: datetime.datetime | datetime.date | None = None
+    modified: datetime.datetime | datetime.date | None = None
     creator: JSKOSSet | None = None
     contributor: JSKOSSet | None = None
     source: JSKOSSet | None = None
@@ -582,15 +582,15 @@ class Distribution(ItemMixin, SemanticallyProcessable[ProcessedDistribution]):
     """A raw distribution in JSKOS, defined in https://gbv.github.io/jskos/#distribution."""
 
     download: AnyUrl
-    access_url: AnyUrl = Field(alias="accessURL")
-    format: AnyUrl
+    access_url: AnyUrl | None = Field(None, alias="accessURL")
+    format: AnyUrl | None = None
     mimetype: AnyUrl | str
-    compress_format: AnyUrl = Field(alias="compressFormat")
-    package_format: AnyUrl = Field(alias="packageFormat")
+    compress_format: AnyUrl | None = Field(None, alias="compressFormat")
+    package_format: AnyUrl | None = Field(None, alias="packageFormat")
     services: list[Service] | None = None
-    license: JSKOSSet
-    size: str
-    checksum: Checksum
+    license: JSKOSSet | None = None
+    size: str | None = None
+    checksum: Checksum | None = None
 
     def process(self, converter: Converter) -> ProcessedDistribution:
         """Process the distribution."""

--- a/src/jskos/api.py
+++ b/src/jskos/api.py
@@ -361,7 +361,7 @@ class ItemMixin(ResourceMixin):
     """An item, defined in https://gbv.github.io/jskos/#item."""
 
     notation: list[str] | None = None
-    preferred_label: LanguageMap | None = Field(None, serialization_alias="prefLabel")
+    preferred_label: LanguageMap | None = Field(None, alias="prefLabel")
     alternative_label: LanguageMapOfList | None = Field(None, serialization_alias="altLabel")
     hidden_label: LanguageMapOfList | None = Field(None, serialization_alias="hiddenLabel")
     scope_note: LanguageMapOfList | None = Field(None, serialization_alias="scopeNote")
@@ -606,7 +606,7 @@ class Distribution(ItemMixin, SemanticallyProcessable[ProcessedDistribution]):
             services=process_many(self.services, converter),
             license=_process_jskos_set(self.license, converter),
             size=self.size,
-            checksum=self.checksum.process(converter),
+            checksum=self.checksum.process(converter) if self.checksum is not None else None,
         )
 
 

--- a/src/jskos/client.py
+++ b/src/jskos/client.py
@@ -14,8 +14,17 @@ __all__ = [
 
 
 class JSKOSClient:
-    """A client to JSKOS API 2.1."""
+    """A client to JSKOS API 2.1.
 
+    .. seealso::
+
+        https://github.com/gbv/jskos-server
+    """
+
+    #: The concept scheme class used. Override this
+    #: if the JSKOS API extends the results. For example,
+    #: BARTOC adds the ``FORMAT`` field in addition to the
+    #: base fields.
     concept_scheme_cls: ClassVar[type[ConceptScheme]] = ConceptScheme
 
     def __init__(self, base: str) -> None:
@@ -46,8 +55,8 @@ class JSKOSClient:
     ) -> list[ConceptScheme]:
         """Get concept schemes, see https://github.com/gbv/jskos-server#get-voc.
 
-        If you want to get the NFDI4Objects Terminologies
-        collection from BARTOC (https://bartoc.org/en/node/18961), then do
+        To get the NFDI4Objects Terminologies collection from BARTOC
+        (https://bartoc.org/en/node/18961), do:
 
         .. code-block:: python
 

--- a/src/jskos/client.py
+++ b/src/jskos/client.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any, TypeAlias, cast
+from typing import Any, ClassVar, Literal, TypeAlias
 
 import requests
 from pydantic import BaseModel
 
-from jskos import ConceptScheme, Item
+from .api import ConceptScheme
 
 __all__ = [
-    "BARTOCClient",
     "JSKOSClient",
     "Status",
     "Validation",
@@ -30,6 +29,8 @@ Validation: TypeAlias = list[bool]
 class JSKOSClient:
     """A client to JSKOS API 2.1."""
 
+    concept_scheme_cls: ClassVar[type[ConceptScheme]] = ConceptScheme
+
     def __init__(self, base: str) -> None:
         """Initialize the client with the base URL."""
         self.base = base.rstrip("/")
@@ -40,108 +41,68 @@ class JSKOSClient:
         res.raise_for_status()
         return res
 
-    def _post(self, end: str, params: dict[str, Any] | None = None, data=None) -> requests.Response:
+    def get_concept_schemes(
+        self,
+        *,
+        uri: str | list[str] | None = None,
+        type: str | None = None,
+        languages: str | list[str] | None = None,
+        subject: str | list[str] | None = None,
+        license: str | list[str] | None = None,
+        publisher: str | None = None,
+        part_of: str | list[str] | None = None,
+        sort: Literal["label", "notation", "created", "modified", "counter"] | None = None,
+        order: Literal["asc", "desc"] | None = None,
+        notation: str | list[str] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[ConceptScheme]:
+        """Get concept schemes, see https://github.com/gbv/jskos-server#get-voc.
+
+        If you want to get the NFDI4Objects Terminologies
+        collection from BARTOC (https://bartoc.org/en/node/18961), then do
+
+        .. code-block:: python
+
+            from jskos.client import BARTOCClient
+
+            client = BARTOCClient()
+            vocabularies = client.get_vocabularies(part_of="https://bartoc.org/en/node/18961")
+        """
+        params: dict[str, Any] = {}
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+        _set(params, "type", type)
+        _set(params, "uri", uri)
+        _set(params, "languages", languages, sep=",")
+        _set(params, "subject", subject)
+        _set(params, "license", license)
+        _set(params, "publisher", publisher)
+        _set(params, "partOf", part_of)
+        _set(params, "sort", sort)
+        _set(params, "order", order)
+        _set(params, "notation", notation)
+
+        res = self._get("/voc", params=params)
+        return [self.concept_scheme_cls.model_validate(record) for record in res.json()]
+
+    def _post(
+        self, end: str, params: dict[str, Any] | None = None, data: dict[str, Any] | None = None
+    ) -> requests.Response:
         url = self.base + end
         res = requests.post(url, timeout=10, params=params, data=data)
         res.raise_for_status()
         return res
 
-    def get_status(self) -> Status:
-        """Get the JSKOS API status, see https://github.com/gbv/jskos-server#get-status."""
-        raise NotImplementedError
 
-    def get_check_auth(self):
-        """Check whether a user is authorized, see https://github.com/gbv/jskos-server#get-checkauth."""
-        raise NotImplementedError
-
-    def get_validate(
-        self,
-        url: str,
-        object_type: type[Item],
-        unknown_fields: bool | None = None,
-        known_schemes: bool | None = None,
-    ) -> Validation:
-        """Validate a JSKOS object via a GET request, see https://github.com/gbv/jskos-server#get-validate.
-
-        :param url: The URL for the object to validate.
-        :param object_type: See https://gbv.github.io/jskos/#object-types
-        :param unknown_fields: If set to true, will disallow unknown fields inside
-            objects
-        :param known_schemes: If set to true, will allow concepts that are not in
-            schemes in the database
-
-        :returns: A validation object
-        """
-        params: dict[str, Any] = {
-            "url": url,
-            # FIXME this should probably get an explicit mapping
-            "type": object_type.__name__.lower(),
-        }
-        if unknown_fields is not None:
-            params["unknownFields"] = unknown_fields
-        if known_schemes is not None:
-            params["knownSchemes"] = known_schemes
-        res = self._get("/validate", params=params)
-        return cast(Validation, res.json())
-
-    def post_validate(
-        self,
-        obj: Item,
-        unknown_fields: bool | None = None,
-        known_schemes: bool | None = None,
-    ) -> Validation:
-        """Validate a JSKOS object via a POST request, see https://github.com/gbv/jskos-server#post-validate.
-
-        :param obj: A JSKOS object
-        :param unknown_fields: If set to true, will disallow unknown fields inside
-            objects
-        :param known_schemes: If set to true, will allow concepts that are not in
-            schemes in the database
-
-        :returns: A validation object
-        """
-        params: dict[str, Any] = {
-            "type": obj.__class__.__name__.lower(),
-        }
-        if unknown_fields is not None:
-            params["unknownFields"] = unknown_fields
-        if known_schemes is not None:
-            params["knownSchemes"] = known_schemes
-        res = self._post(
-            "/validate", params=params, data=obj.model_dump(exclude_none=True, exclude_unset=True)
-        )
-        return cast(Validation, res.json())
-
-    def get_data(self, uri: str) -> list[dict[str, Any]]:
-        """Get data for entity, passed via URI, see https://github.com/gbv/jskos-server#get-data."""
-        res = self._get("/data", params={"uri": uri})
-        # TODO how to deal with typing?
-        return cast(list[dict[str, Any]], res.json())
-
-    def get_vocabularies(self, *, limit: int | None = None) -> list[ConceptScheme]:
-        """Get concept schemes, see https://github.com/gbv/jskos-server#get-voc."""
-        params: dict[str, Any] = {}
-        if limit is not None:
-            params["limit"] = limit
-        res = self._get("/voc", params=params)
-        return [ConceptScheme.model_validate(record) for record in res.json()]
-
-    def post_vocabulary(self):
-        """Save a concept scheme or multiple concept schemes, see https://github.com/gbv/jskos-server#post-voc."""
-        raise NotImplementedError
-
-    def put_vocabulary(self):
-        """Overwrite a concept scheme or multiple concept schemes, see https://github.com/gbv/jskos-server#put-voc."""
-        raise NotImplementedError
-
-
-# Implement the API at https://bartoc.org/api/
-# this is a subset of JSKOS API, so maybe this
-
-
-class BARTOCClient(JSKOSClient):
-    """A client for BARTOC."""
-
-    def __init__(self) -> None:
-        """Initialize the BARTOC client."""
-        super().__init__("https://bartoc.org/api/")
+def _set(d: dict[str, Any], key: str, value: str | list[str] | None, sep: str = "|") -> None:
+    if value is None:
+        return
+    elif isinstance(value, str):
+        d[key] = value
+    elif isinstance(value, list):
+        d[key] = sep.join(value)
+    else:
+        raise TypeError

--- a/src/jskos/client.py
+++ b/src/jskos/client.py
@@ -1,19 +1,17 @@
-from typing import Any
+"""A client to JSKOS API 2.1."""
+
+from __future__ import annotations
+
+from typing import Any, cast
 
 import requests
 
 from jskos import ConceptScheme
 
 __all__ = [
-    "JSKOSClient",
     "BARTOCClient",
+    "JSKOSClient",
 ]
-
-# Implement the API at https://bartoc.org/api/
-# this is a subset of JSKOS API, so maybe this
-# actually needs to go in the JSKOS package later?
-
-BASE_URL = "https://bartoc.org/api/"
 
 
 class JSKOSClient:
@@ -26,6 +24,7 @@ class JSKOSClient:
     def _get(self, end: str, params: dict[str, Any] | None = None) -> requests.Response:
         url = self.base + end
         res = requests.get(url, timeout=10, params=params)
+        res.raise_for_status()
         return res
 
     def get_status(self):
@@ -33,20 +32,22 @@ class JSKOSClient:
         raise NotImplementedError
 
     def get_check_auth(self):
-        # https://github.com/gbv/jskos-server#get-checkauth
+        """Check whether a user is authorizeed, see https://github.com/gbv/jskos-server#get-checkauth."""
         raise NotImplementedError
 
     def get_validate(self):
-        # https://github.com/gbv/jskos-server#post-validate
+        """Validate a JSKOS object via a GET request, see https://github.com/gbv/jskos-server#get-validate."""
         raise NotImplementedError
 
     def post_validate(self):
-        # https://github.com/gbv/jskos-server#post-validate
+        """Validate a JSKOS object via a POST request, see https://github.com/gbv/jskos-server#post-validate."""
         raise NotImplementedError
 
-    def get_data(self):
-        # https://github.com/gbv/jskos-server#get-data
-        raise NotImplementedError
+    def get_data(self, uri: str) -> list[dict[str, Any]]:
+        """Get data for entity, passed via URI, see https://github.com/gbv/jskos-server#get-data."""
+        res = self._get("/data", params={"uri": uri})
+        # TODO how to deal with typing?
+        return cast(list[dict[str, Any]], res.json())
 
     def get_vocabularies(self, *, limit: int | None = None) -> list[ConceptScheme]:
         """Get concept schemes, see https://github.com/gbv/jskos-server#get-voc."""
@@ -54,16 +55,19 @@ class JSKOSClient:
         if limit is not None:
             params["limit"] = limit
         res = self._get("/voc", params=params)
-        res.raise_for_status()
         return [ConceptScheme.model_validate(record) for record in res.json()]
 
     def post_vocabulary(self):
-        # https://github.com/gbv/jskos-server#post-voc
+        """Save a concept scheme or multiple concept schemes, see https://github.com/gbv/jskos-server#post-voc."""
         raise NotImplementedError
 
     def put_vocabulary(self):
-        # https://github.com/gbv/jskos-server#put-voc
+        """Overwrite a concept scheme or multiple concept schemes, see https://github.com/gbv/jskos-server#put-voc."""
         raise NotImplementedError
+
+
+# Implement the API at https://bartoc.org/api/
+# this is a subset of JSKOS API, so maybe this
 
 
 class BARTOCClient(JSKOSClient):
@@ -71,4 +75,4 @@ class BARTOCClient(JSKOSClient):
 
     def __init__(self) -> None:
         """Initialize the BARTOC client."""
-        super().__init__(BASE_URL)
+        super().__init__("https://bartoc.org/api/")

--- a/src/jskos/client.py
+++ b/src/jskos/client.py
@@ -2,28 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Literal, TypeAlias
+from typing import Any, ClassVar, Literal
 
 import requests
-from pydantic import BaseModel
 
 from .api import ConceptScheme
 
 __all__ = [
     "JSKOSClient",
-    "Status",
-    "Validation",
 ]
-
-
-class Status(BaseModel):
-    """A status, see https://github.com/gbv/jskos-server#get-status."""
-
-    # TODO implement based on https://gbv.github.io/jskos-server/status.schema.json
-
-
-#:
-Validation: TypeAlias = list[bool]
 
 
 class JSKOSClient:

--- a/src/jskos/client.py
+++ b/src/jskos/client.py
@@ -2,16 +2,29 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, TypeAlias, cast
 
 import requests
+from pydantic import BaseModel
 
-from jskos import ConceptScheme
+from jskos import ConceptScheme, Item
 
 __all__ = [
     "BARTOCClient",
     "JSKOSClient",
+    "Status",
+    "Validation",
 ]
+
+
+class Status(BaseModel):
+    """A status, see https://github.com/gbv/jskos-server#get-status."""
+
+    # TODO implement based on https://gbv.github.io/jskos-server/status.schema.json
+
+
+#:
+Validation: TypeAlias = list[bool]
 
 
 class JSKOSClient:
@@ -27,21 +40,77 @@ class JSKOSClient:
         res.raise_for_status()
         return res
 
-    def get_status(self):
+    def _post(self, end: str, params: dict[str, Any] | None = None, data=None) -> requests.Response:
+        url = self.base + end
+        res = requests.post(url, timeout=10, params=params, data=data)
+        res.raise_for_status()
+        return res
+
+    def get_status(self) -> Status:
         """Get the JSKOS API status, see https://github.com/gbv/jskos-server#get-status."""
         raise NotImplementedError
 
     def get_check_auth(self):
-        """Check whether a user is authorizeed, see https://github.com/gbv/jskos-server#get-checkauth."""
+        """Check whether a user is authorized, see https://github.com/gbv/jskos-server#get-checkauth."""
         raise NotImplementedError
 
-    def get_validate(self):
-        """Validate a JSKOS object via a GET request, see https://github.com/gbv/jskos-server#get-validate."""
-        raise NotImplementedError
+    def get_validate(
+        self,
+        url: str,
+        object_type: type[Item],
+        unknown_fields: bool | None = None,
+        known_schemes: bool | None = None,
+    ) -> Validation:
+        """Validate a JSKOS object via a GET request, see https://github.com/gbv/jskos-server#get-validate.
 
-    def post_validate(self):
-        """Validate a JSKOS object via a POST request, see https://github.com/gbv/jskos-server#post-validate."""
-        raise NotImplementedError
+        :param url: The URL for the object to validate.
+        :param object_type: See https://gbv.github.io/jskos/#object-types
+        :param unknown_fields: If set to true, will disallow unknown fields inside
+            objects
+        :param known_schemes: If set to true, will allow concepts that are not in
+            schemes in the database
+
+        :returns: A validation object
+        """
+        params: dict[str, Any] = {
+            "url": url,
+            # FIXME this should probably get an explicit mapping
+            "type": object_type.__name__.lower(),
+        }
+        if unknown_fields is not None:
+            params["unknownFields"] = unknown_fields
+        if known_schemes is not None:
+            params["knownSchemes"] = known_schemes
+        res = self._get("/validate", params=params)
+        return cast(Validation, res.json())
+
+    def post_validate(
+        self,
+        obj: Item,
+        unknown_fields: bool | None = None,
+        known_schemes: bool | None = None,
+    ) -> Validation:
+        """Validate a JSKOS object via a POST request, see https://github.com/gbv/jskos-server#post-validate.
+
+        :param obj: A JSKOS object
+        :param unknown_fields: If set to true, will disallow unknown fields inside
+            objects
+        :param known_schemes: If set to true, will allow concepts that are not in
+            schemes in the database
+
+        :returns: A validation object
+        """
+        params: dict[str, Any] = {
+            "type": obj.__class__.__name__.lower(),
+        }
+        if unknown_fields is not None:
+            params["unknownFields"] = unknown_fields
+        if known_schemes is not None:
+            params["knownSchemes"] = known_schemes
+        res = self._post(
+            "/validate", params=params, data=obj.model_dump(exclude_none=True, exclude_unset=True)
+        )
+        return cast(Validation, res.json())
 
     def get_data(self, uri: str) -> list[dict[str, Any]]:
         """Get data for entity, passed via URI, see https://github.com/gbv/jskos-server#get-data."""

--- a/src/jskos/client.py
+++ b/src/jskos/client.py
@@ -88,14 +88,6 @@ class JSKOSClient:
         res = self._get("/voc", params=params)
         return [self.concept_scheme_cls.model_validate(record) for record in res.json()]
 
-    def _post(
-        self, end: str, params: dict[str, Any] | None = None, data: dict[str, Any] | None = None
-    ) -> requests.Response:
-        url = self.base + end
-        res = requests.post(url, timeout=10, params=params, data=data)
-        res.raise_for_status()
-        return res
-
 
 def _set(d: dict[str, Any], key: str, value: str | list[str] | None, sep: str = "|") -> None:
     if value is None:

--- a/src/jskos/client.py
+++ b/src/jskos/client.py
@@ -1,0 +1,74 @@
+from typing import Any
+
+import requests
+
+from jskos import ConceptScheme
+
+__all__ = [
+    "JSKOSClient",
+    "BARTOCClient",
+]
+
+# Implement the API at https://bartoc.org/api/
+# this is a subset of JSKOS API, so maybe this
+# actually needs to go in the JSKOS package later?
+
+BASE_URL = "https://bartoc.org/api/"
+
+
+class JSKOSClient:
+    """A client to JSKOS API 2.1."""
+
+    def __init__(self, base: str) -> None:
+        """Initialize the client with the base URL."""
+        self.base = base.rstrip("/")
+
+    def _get(self, end: str, params: dict[str, Any] | None = None) -> requests.Response:
+        url = self.base + end
+        res = requests.get(url, timeout=10, params=params)
+        return res
+
+    def get_status(self):
+        """Get the JSKOS API status, see https://github.com/gbv/jskos-server#get-status."""
+        raise NotImplementedError
+
+    def get_check_auth(self):
+        # https://github.com/gbv/jskos-server#get-checkauth
+        raise NotImplementedError
+
+    def get_validate(self):
+        # https://github.com/gbv/jskos-server#post-validate
+        raise NotImplementedError
+
+    def post_validate(self):
+        # https://github.com/gbv/jskos-server#post-validate
+        raise NotImplementedError
+
+    def get_data(self):
+        # https://github.com/gbv/jskos-server#get-data
+        raise NotImplementedError
+
+    def get_vocabularies(self, *, limit: int | None = None) -> list[ConceptScheme]:
+        """Get concept schemes, see https://github.com/gbv/jskos-server#get-voc."""
+        params: dict[str, Any] = {}
+        if limit is not None:
+            params["limit"] = limit
+        res = self._get("/voc", params=params)
+        res.raise_for_status()
+        return [ConceptScheme.model_validate(record) for record in res.json()]
+
+    def post_vocabulary(self):
+        # https://github.com/gbv/jskos-server#post-voc
+        raise NotImplementedError
+
+    def put_vocabulary(self):
+        # https://github.com/gbv/jskos-server#put-voc
+        raise NotImplementedError
+
+
+class BARTOCClient(JSKOSClient):
+    """A client for BARTOC."""
+
+    def __init__(self) -> None:
+        """Initialize the BARTOC client."""
+        super().__init__(BASE_URL)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,24 @@
+"""Test the JSKOS API client."""
+
+import unittest
+from typing import ClassVar
+
+from jskos.client import JSKOSClient
+from jskos import ConceptScheme
+
+
+class TestJSKOSClient(unittest.TestCase):
+    """Test the JSKOS API client."""
+    client: ClassVar[JSKOSClient]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Set up the test case."""
+        cls.client = JSKOSClient("https://coli-conc.gbv.de/api/")
+
+    def test_voc(self) -> None:
+        """Test getting all concept schemes."""
+        results = self.client.get_vocabularies(limit=1)
+        self.assertEqual(1, len(results))
+        self.assertIsInstance(results[0], ConceptScheme)
+        self.assertEqual("http://dewey.info/scheme/edition/e23/", results[0].uri)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,9 @@
 import unittest
 from typing import ClassVar
 
-from jskos import ConceptScheme, JSKOSClient
+from jskos import JSKOSClient
+
+BARTOC_BASE_URL = "https://bartoc.org/api/"
 
 
 class TestJSKOSClient(unittest.TestCase):
@@ -14,11 +16,21 @@ class TestJSKOSClient(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         """Set up the test case."""
-        cls.client = JSKOSClient("https://coli-conc.gbv.de/api/")
+        cls.client = JSKOSClient(BARTOC_BASE_URL)
 
-    def test_voc(self) -> None:
-        """Test getting all concept schemes."""
-        results = self.client.get_vocabularies(limit=1)
-        self.assertEqual(1, len(results))
-        self.assertIsInstance(results[0], ConceptScheme)
-        self.assertEqual("http://dewey.info/scheme/edition/e23/", results[0].uri)
+    def test_get_collection(self) -> None:
+        """Test getting a collection from BARTOC."""
+        vocabularies = self.client.get_concept_schemes(part_of="http://bartoc.org/en/node/18961")
+        self.assertLessEqual(80, len(vocabularies))
+
+        # on March 2nd, 2026, there were 85 unique records in the
+        # NFDI4Objects collection. this tests for a subset of them
+        uris = {str(v.uri) for v in vocabularies}
+        self.assertLessEqual(
+            {
+                "http://bartoc.org/en/node/18653",  # LIDO Terminology Actor Type
+                "http://bartoc.org/en/node/2021",  # ORCiD
+                "http://bartoc.org/en/node/459",  # Iconclass
+            },
+            uris,
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,8 +3,7 @@
 import unittest
 from typing import ClassVar
 
-from jskos import ConceptScheme
-from jskos.client import JSKOSClient
+from jskos import ConceptScheme, JSKOSClient
 
 
 class TestJSKOSClient(unittest.TestCase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,12 +3,13 @@
 import unittest
 from typing import ClassVar
 
-from jskos.client import JSKOSClient
 from jskos import ConceptScheme
+from jskos.client import JSKOSClient
 
 
 class TestJSKOSClient(unittest.TestCase):
     """Test the JSKOS API client."""
+
     client: ClassVar[JSKOSClient]
 
     @classmethod


### PR DESCRIPTION
In a first pass, this implements a client JSKOS API 2.1 and the `/voc` endpoint, which is needed by https://github.com/biopragmatics/bioregistry/issues/1814 and https://github.com/biopragmatics/bioregistry/issues/1817