### PR TITLE
Improve handling of concept schemes

### DIFF
--- a/src/jskos/api.py
+++ b/src/jskos/api.py
@@ -655,12 +655,9 @@ class ProcessedConceptScheme(ProcessedDataset):
     uri_pattern: str | None = None
     notation_pattern: str | None = None
     notation_examples: list[str] | None = None
-    # concepts
-    # types
-    # distributions
-    # extent
-    # languages
-    # license
+    concepts: list[ProcessedConcept] | None = Field(None)
+    types: list[ProcessedConcept] | None = Field(None)
+    languages: list[LanguageCode] | None = Field(None)
 
 
 class ConceptScheme(DatasetMixin, SemanticallyProcessable[ProcessedConceptScheme]):
@@ -668,18 +665,14 @@ class ConceptScheme(DatasetMixin, SemanticallyProcessable[ProcessedConceptScheme
 
     model_config = {"populate_by_name": True}
 
-    top_concepts: list[Concept] | None = Field(None, alias="from")
+    top_concepts: list[Concept] | None = Field(None, alias="topConcepts")
     namespace: AnyUrl | None = None
     uri_pattern: str | None = Field(None, alias="uriPattern")
     notation_pattern: str | None = Field(None, alias="notationPattern")
     notation_examples: list[str] | None = Field(None, alias="notationExamples")
-
-    # concepts
-    # types
-    # distributions
-    # extent
-    # languages
-    # license
+    concepts: list[Concept] | None = Field(None)
+    types: list[Concept] | None = Field(None)
+    languages: list[LanguageCode] | None = Field(None)
 
     def process(self, converter: curies.Converter) -> ProcessedConceptScheme:
         """Process the concept scheme."""
@@ -692,12 +685,9 @@ class ConceptScheme(DatasetMixin, SemanticallyProcessable[ProcessedConceptScheme
             uri_pattern=self.uri_pattern,
             notation_pattern=self.notation_pattern,
             notation_examples=self.notation_examples,
-            # concepts
-            # types
-            # distributions
-            # extent
-            # languages
-            # license
+            concepts=process_many(self.concepts, converter),
+            types=process_many(self.types, converter),
+            languages=self.languages,
         )
 
 

--- a/src/jskos/api.py
+++ b/src/jskos/api.py
@@ -45,6 +45,7 @@ __all__ = [
     "ProcessedResource",
     "ProcessedService",
     "Resource",
+    "pop_bartoc_extras",
     "process",
     "read",
 ]
@@ -946,3 +947,12 @@ def _parse_optional_url(url: str | AnyUrl | None, converter: Converter) -> Refer
     if url is None:
         return None
     return _parse_url(url, converter)
+
+
+def pop_bartoc_extras(record: dict[str, Any]) -> dict[str, Any]:
+    """Pop off BARTOC-specific content that isn't part of the JSKOS schema for Concept Schemes."""
+    return {
+        key: value
+        for key in ["ACCESS", "API", "FORMAT", "ADDRESS", "CQLKEYMARCSPEC", "PICAPATH", "EXAMPLES"]
+        if (value := record.pop(key, None))
+    }

--- a/tests/resources/bartoc_241.json
+++ b/tests/resources/bartoc_241.json
@@ -1,0 +1,295 @@
+{
+  "@context": "https://gbv.github.io/jskos/context.json",
+  "ACCESS": [
+    {
+      "uri": "http://bartoc.org/en/Access/Licensed"
+    },
+    {
+      "uri": "http://bartoc.org/en/Access/Free"
+    }
+  ],
+  "ADDRESS": {
+    "code": "43017",
+    "country": "United States",
+    "locality": "Dublin",
+    "region": "OH",
+    "street": "6565 Kilgour Place"
+  },
+  "API": [
+    {
+      "type": "http://bartoc.org/api-type/jskos",
+      "url": "https://coli-conc.gbv.de/api/"
+    },
+    {
+      "type": "http://bartoc.org/api-type/jskos",
+      "url": "https://bartoc.org/api/"
+    },
+    {
+      "type": "http://bartoc.org/api-type/skosmos",
+      "url": "https://data.ub.uio.no/skosmos/ddc/"
+    }
+  ],
+  "CQLKEY": "ddc",
+  "EXAMPLES": [
+    "612.112"
+  ],
+  "FORMAT": [
+    {
+      "uri": "http://bartoc.org/en/Format/CD-ROM"
+    },
+    {
+      "uri": "http://bartoc.org/en/Format/Floppy-Disc"
+    },
+    {
+      "uri": "http://bartoc.org/en/Format/Microform"
+    },
+    {
+      "uri": "http://bartoc.org/en/Format/Online"
+    },
+    {
+      "uri": "http://bartoc.org/en/Format/Printed"
+    }
+  ],
+  "MARCSPEC": "082|083",
+  "PICAPATH": "045F$a",
+  "contributor": [
+    {
+      "prefLabel": {
+        "en": "Sabrina Gaab"
+      },
+      "uri": "https://coli-conc.gbv.de/login/users/2062a0cd-5f05-400e-898a-124c0c96767c"
+    },
+    {
+      "prefLabel": {
+        "en": "David-Benjamin Rohrer"
+      },
+      "uri": "https://coli-conc.gbv.de/login/users/eccf8bf8-8194-4496-a9af-36f781688e6b"
+    },
+    {
+      "prefLabel": {
+        "en": "Ziyoung Park"
+      },
+      "uri": "https://coli-conc.gbv.de/login/users/e4529559-e50c-4395-9efe-2e5b86f6dbeb"
+    },
+    {
+      "prefLabel": {
+        "en": "JakobVoss"
+      },
+      "uri": "https://coli-conc.gbv.de/login/users/3a1bb23f-8d60-4b7a-8bec-cc419d7f6ab6"
+    },
+    {
+      "uri": "https://coli-conc.gbv.de/login/users/c0c1914a-f9d6-4b92-a624-bf44118b6619",
+      "prefLabel": {
+        "en": "Stefan Peters"
+      }
+    }
+  ],
+  "created": "2013-09-06T14:57:00Z",
+  "creator": [
+    {
+      "uri": "https://coli-conc.gbv.de/login/users/2062a0cd-5f05-400e-898a-124c0c96767c",
+      "prefLabel": {
+        "en": "Sabrina Gaab"
+      }
+    }
+  ],
+  "definition": {
+    "en": [
+      "\"The Dewey Decimal Classification (DDC) system, devised by library pioneer Melvil Dewey in the 1870s and owned by OCLC since 1988, provides a dynamic structure for the organization of library collections. Now in its 23rd edition, and available in print and Web versions, the DDC is the world's most widely used library classification system.\""
+    ]
+  },
+  "distributions": [
+    {
+      "download": "https://bartoc.org/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=ndjson",
+      "format": "http://format.gbv.de/jskos",
+      "mimetype": "application/x-ndjson; charset=utf-8"
+    },
+    {
+      "download": "https://bartoc.org/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=json",
+      "mimetype": "application/json; charset=utf-8"
+    },
+    {
+      "download": "http://localhost:3012/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=ndjson",
+      "format": "http://format.gbv.de/jskos",
+      "mimetype": "application/x-ndjson; charset=utf-8"
+    },
+    {
+      "download": "http://localhost:3012/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=json",
+      "mimetype": "application/json; charset=utf-8"
+    },
+    {
+      "download": "https://bartoc.gbv.de/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=ndjson",
+      "format": "http://format.gbv.de/jskos",
+      "mimetype": "application/x-ndjson; charset=utf-8"
+    },
+    {
+      "download": "https://bartoc.gbv.de/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=json",
+      "mimetype": "application/json; charset=utf-8"
+    },
+    {
+      "download": "https://coli-conc.gbv.de/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=ndjson",
+      "format": "http://format.gbv.de/jskos",
+      "mimetype": "application/x-ndjson; charset=utf-8"
+    },
+    {
+      "download": "https://coli-conc.gbv.de/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=json",
+      "mimetype": "application/json; charset=utf-8"
+    },
+    {
+      "download": "https://coli-conc.gbv.de/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=ndjson",
+      "format": "http://format.gbv.de/jskos",
+      "mimetype": "application/x-ndjson; charset=utf-8"
+    },
+    {
+      "download": "https://coli-conc.gbv.de/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=json",
+      "mimetype": "application/json; charset=utf-8"
+    },
+    {
+      "download": "https://coli-conc.gbv.de/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=ndjson",
+      "format": "http://format.gbv.de/jskos",
+      "mimetype": "application/x-ndjson; charset=utf-8"
+    },
+    {
+      "download": "https://coli-conc.gbv.de/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=json",
+      "mimetype": "application/json; charset=utf-8"
+    },
+    {
+      "download": "https://coli-conc.gbv.de/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=ndjson",
+      "format": "http://format.gbv.de/jskos",
+      "mimetype": "application/x-ndjson; charset=utf-8"
+    },
+    {
+      "download": "https://coli-conc.gbv.de/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=json",
+      "mimetype": "application/json; charset=utf-8"
+    },
+    {
+      "download": "https://coli-conc.gbv.de/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=ndjson",
+      "format": "http://format.gbv.de/jskos",
+      "mimetype": "application/x-ndjson; charset=utf-8"
+    },
+    {
+      "download": "https://coli-conc.gbv.de/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=json",
+      "mimetype": "application/json; charset=utf-8"
+    },
+    {
+      "download": "https://coli-conc.gbv.de/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=ndjson",
+      "format": "http://format.gbv.de/jskos",
+      "mimetype": "application/x-ndjson; charset=utf-8"
+    },
+    {
+      "download": "https://coli-conc.gbv.de/api/voc/concepts?uri=http%3A%2F%2Fbartoc.org%2Fen%2Fnode%2F241&download=json",
+      "mimetype": "application/json; charset=utf-8"
+    }
+  ],
+  "identifier": [
+    "http://www.wikidata.org/entity/Q48460",
+    "http://dewey.info/scheme/edition/e23/"
+  ],
+  "languages": [
+    "ar",
+    "nb",
+    "zh",
+    "fr",
+    "de",
+    "el",
+    "he",
+    "is",
+    "it",
+    "ru",
+    "es",
+    "sv",
+    "vi"
+  ],
+  "license": [
+    {
+      "uri": "http://creativecommons.org/licenses/by-nc-nd/3.0/"
+    },
+    {
+      "uri": "http://rightsstatements.org/vocab/InC/1.0/"
+    }
+  ],
+  "modified": "2025-11-25T07:53:26.015Z",
+  "notation": [
+    "DDC"
+  ],
+  "notationPattern": "(([0-9][0-9]?|[0-9]{3}(-[0-9]{3})?|[0-9]{3}(-[0-9]{3}(:[0-9]+)?)?|[0-9]{3}\\.[0-9]+(-[0-9]{3}\\.[0-9]+(:[0-9]+)?)?|T[1-9][A-Z]?--[0-9]+(-T[1-9][A-Z]?--[0-9]+(:[0-9]+)?)?|[1-9][A-Z]?--[0-9]+(-[1-9][A-Z]?--[0-9]+(:[0-9]+)?)?)?)",
+  "partOf": [
+    {
+      "uri": "http://bartoc.org/en/node/18926"
+    },
+    {
+      "uri": "http://bartoc.org/en/node/18930"
+    }
+  ],
+  "prefLabel": {
+    "de": "Dewey-Dezimalklassifikation",
+    "en": "Dewey Decimal Classification"
+  },
+  "publisher": [
+    {
+      "prefLabel": {
+        "en": "Online Computer Library Center (OCLC)"
+      },
+      "uri": "http://viaf.org/viaf/156508705"
+    }
+  ],
+  "startDate": "1876",
+  "subject": [
+    {
+      "uri": "http://dewey.info/class/0/e23/",
+      "inScheme": [
+        {
+          "uri": "http://bartoc.org/en/node/241"
+        }
+      ],
+      "notation": [
+        "0"
+      ]
+    },
+    {
+      "uri": "http://dewey.info/class/001/e23/",
+      "inScheme": [
+        {
+          "uri": "http://bartoc.org/en/node/241"
+        }
+      ],
+      "notation": [
+        "001"
+      ]
+    },
+    {
+      "uri": "http://dewey.info/class/025/e23/",
+      "inScheme": [
+        {
+          "uri": "http://bartoc.org/en/node/241"
+        }
+      ],
+      "notation": [
+        "025"
+      ]
+    },
+    {
+      "uri": "http://www.iskoi.org/ilc/2/class/V",
+      "inScheme": [
+        {
+          "uri": "http://www.iskoi.org/ilc/2/scheme"
+        }
+      ]
+    },
+    {
+      "uri": "http://www.iskoi.org/ilc/2/class/yvl",
+      "inScheme": [
+        {
+          "uri": "http://www.iskoi.org/ilc/2/scheme"
+        }
+      ]
+    }
+  ],
+  "type": [
+    "http://www.w3.org/2004/02/skos/core#ConceptScheme",
+    "http://w3id.org/nkos/nkostype#classification_schema"
+  ],
+  "uri": "http://bartoc.org/en/node/241",
+  "uriPattern": "http://dewey.info/class/(.+)/e23/",
+  "url": "http://www.oclc.org/dewey/"
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,12 +1,26 @@
 """Test the API."""
 
+import json
 import unittest
+from pathlib import Path
 
 import curies
 from curies import Reference
 
 import jskos
-from jskos.api import Concept, Location, Occurrence, Registry, Resource
+from jskos.api import (
+    Concept,
+    ConceptScheme,
+    Location,
+    Occurrence,
+    Registry,
+    Resource,
+    pop_bartoc_extras,
+)
+
+HERE = Path(__file__).parent.resolve()
+RESOURCES = HERE / "resources"
+BARTOC_241_PATH = RESOURCES.joinpath("bartoc_241.json")
 
 converter = curies.Converter.from_prefix_map(
     {
@@ -150,6 +164,12 @@ class TestExamples(unittest.TestCase):
         self.assertEqual(
             Reference(prefix="wikidata", identifier="Q406"), processed_concept.reference
         )
+
+    def test_bartoc_241_dewey_decimal(self) -> None:
+        """Test parsing the BARTOC record 241 for Dewey Decimal Classification."""
+        record = json.loads(BARTOC_241_PATH.read_text())
+        _bartoc_extras = pop_bartoc_extras(record)
+        ConceptScheme.model_validate(record, extra="forbid")
 
 
 class TestJSKOS(unittest.TestCase):


### PR DESCRIPTION
This PR does the following:

1. Add the missing fields for the concept scheme that were commented
2. Fix a typo in the alias for top concepts
3. Adds an example from BARTOC that doesn't appear to work (longer explanation below)


It seems it's not possible to parse concept schemes from BARTOC when forbidding extras. I'll use http://bartoc.org/en/node/241 (Dewey Decimal Classification) to illustrate.

First, I identified some fields in BARTOC that appear to be additions to the standard (`["ACCESS", "API", "FORMAT", "ADDRESS", "CQLKEYMARCSPEC", "PICAPATH", "EXAMPLES"]`) and removed those (for now). I'll implement custom logic for working with those in downstream applications, e.g., by extending the Pydantic model for the Concept Scheme class.

The next issue is that the `creator` and `contributor` fields. These are defined in the Resource class and inherited by the Concept Scheme class.

![](https://gbv.github.io/jskos/types.svg)

Inside the Resource class (see https://gbv.github.io/jskos/#resource), `creator` and `concept` are defined as `set` (see https://gbv.github.io/jskos/#set). From my interpretation, a JSKOS `set` is a list of `Resource`.

The problem with the BARTOC data is the objects in the data appears to be `Items` because they include `prefLabel`. I'm not sure if the definition of `set` means that any object that's any descendant of Resource is allowed. As I'm writing this, I guess this could make sense, but it's a bit of a problem for how Pydantic works, since I don't think there's a field that could be used as a discriminator (https://docs.pydantic.dev/latest/concepts/unions/)